### PR TITLE
VertxPullInDepsMojo - resolve relative target/mods path

### DIFF
--- a/plugin/src/main/java/org/vertx/maven/plugin/mojo/BaseVertxMojo.java
+++ b/plugin/src/main/java/org/vertx/maven/plugin/mojo/BaseVertxMojo.java
@@ -58,6 +58,12 @@ public abstract class BaseVertxMojo extends AbstractMojo {
   @Parameter(property = "run.instances", defaultValue = "1")
   protected Integer instances;
 
+  /**
+   * The mods directory.  The default is relative path target/mods.
+   */
+  @Parameter(property = "vertx.modsdir", defaultValue = "target/mods")
+  protected File modsdir;
+
   protected JsonObject getConf() {
     JsonObject config = null;
     final String confContent = readConfigFile(configFile);

--- a/plugin/src/main/java/org/vertx/maven/plugin/mojo/VertxPullInDepsMojo.java
+++ b/plugin/src/main/java/org/vertx/maven/plugin/mojo/VertxPullInDepsMojo.java
@@ -21,9 +21,6 @@ public class VertxPullInDepsMojo extends BaseVertxMojo {
   @Parameter(property = "vertx.pullindeps", defaultValue = "false")
   protected Boolean pullindeps;
 
-  @Parameter(property = "vertx.modsdir", defaultValue = "target/mods")
-  protected File modsdir;
-
   @Override
   public void execute() throws MojoExecutionException {
     try {

--- a/plugin/src/main/java/org/vertx/maven/plugin/mojo/VertxRunModMojo.java
+++ b/plugin/src/main/java/org/vertx/maven/plugin/mojo/VertxRunModMojo.java
@@ -40,7 +40,7 @@ public class VertxRunModMojo extends BaseVertxMojo {
   public void execute() throws MojoExecutionException {
 
     try {
-      System.setProperty("vertx.mods", "target/mods");
+      System.setProperty("vertx.mods", modsdir.getAbsolutePath());
       final PlatformManager pm = factory.createPlatformManager();
       final CountDownLatch latch = new CountDownLatch(1);
       pm.deployModule(moduleName, getConf(), instances,
@@ -50,8 +50,11 @@ public class VertxRunModMojo extends BaseVertxMojo {
               if (event.succeeded()) {
                 getLog().info("CTRL-C to stop server");
               } else {
-                getLog().info(
-                    "Could not find the module. Did you forget to do mvn package?");
+                if (event.cause() != null) {
+                  getLog().error(event.cause());
+                } else {
+                  getLog().info("Could not find the module. Did you forget to do mvn package?");
+                }
                 latch.countDown();
               }
             }


### PR DESCRIPTION
When there are nested projects, target/mods was not resolving correctly.

See http://maven.apache.org/plugin-developers/common-bugs.html#Resolving_Relative_Paths for an explanation of how to resolve relative paths

"Many Maven plugins can get this resolution automatically if they declare their affected mojo parameters of type java.io.File instead of java.lang.String. This subtle difference in parameter types will trigger a feature known as path translation, i.e. the Maven core will automatically resolve relative paths when it pumps the XML configuration into a mojo."
