### PR TITLE
Added configurable resource directories that will be added to the plugin...

### DIFF
--- a/plugin/src/main/java/org/vertx/maven/plugin/mojo/VertxRunModMojo.java
+++ b/plugin/src/main/java/org/vertx/maven/plugin/mojo/VertxRunModMojo.java
@@ -40,6 +40,7 @@ public class VertxRunModMojo extends BaseVertxMojo {
   public void execute() throws MojoExecutionException {
 
     try {
+      initClassLoader();
       System.setProperty("vertx.mods", modsdir.getAbsolutePath());
       final PlatformManager pm = factory.createPlatformManager();
       final CountDownLatch latch = new CountDownLatch(1);


### PR DESCRIPTION
...'s class loader.  For example this can be used to specify a directory containing a log4j.properties file and make it available to the plugin during vertx:runmod.
