### PR TITLE
systemPropertyVariables configuration option

### DIFF
--- a/plugin/src/main/java/org/vertx/maven/plugin/mojo/BaseVertxMojo.java
+++ b/plugin/src/main/java/org/vertx/maven/plugin/mojo/BaseVertxMojo.java
@@ -24,6 +24,8 @@ import org.vertx.java.core.json.JsonObject;
 import java.io.File;
 import java.io.IOException;
 import java.net.URI;
+import java.util.Collections;
+import java.util.Map;
 
 import static java.nio.file.Files.readAllBytes;
 
@@ -63,6 +65,11 @@ public abstract class BaseVertxMojo extends AbstractMojo {
    * The mods directory.  The default is relative path target/mods.
    */
   protected File modsDir = new File("target/mods");
+
+  /**
+   * List of system properties to set when running a module.
+   */
+  protected Map<String, String> systemPropertyVariables = Collections.EMPTY_MAP;
 
   protected JsonObject getConf() {
     JsonObject config = null;

--- a/plugin/src/main/java/org/vertx/maven/plugin/mojo/RunModOnClasspathMojo.java
+++ b/plugin/src/main/java/org/vertx/maven/plugin/mojo/RunModOnClasspathMojo.java
@@ -13,6 +13,7 @@ import java.net.MalformedURLException;
 import java.net.URL;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Map;
 import java.util.concurrent.CountDownLatch;
 
 import static java.lang.Long.MAX_VALUE;
@@ -67,6 +68,9 @@ public class RunModOnClasspathMojo extends BaseVertxMojo {
   protected void doExecute(URL[] classpath) throws MojoExecutionException {
 
     try {
+      for (final Map.Entry<String, String> entry : systemPropertyVariables.entrySet()) {
+        System.setProperty(entry.getKey(), entry.getValue());
+      }
       System.setProperty("vertx.mods", modsDir.getAbsolutePath());
       final PlatformManager pm = PlatformLocator.factory.createPlatformManager();
       final CountDownLatch latch = new CountDownLatch(1);

--- a/plugin/src/main/java/org/vertx/maven/plugin/mojo/VertxRunModMojo.java
+++ b/plugin/src/main/java/org/vertx/maven/plugin/mojo/VertxRunModMojo.java
@@ -7,6 +7,7 @@ import org.vertx.java.core.AsyncResult;
 import org.vertx.java.core.Handler;
 import org.vertx.java.platform.PlatformManager;
 
+import java.util.Map;
 import java.util.concurrent.CountDownLatch;
 
 import static java.lang.Long.MAX_VALUE;
@@ -43,6 +44,9 @@ public class VertxRunModMojo extends BaseVertxMojo {
   public void execute() throws MojoExecutionException {
 
     try {
+      for (final Map.Entry<String, String> entry : systemPropertyVariables.entrySet()) {
+        System.setProperty(entry.getKey(), entry.getValue());
+      }
       System.setProperty("vertx.mods", modsDir.getAbsolutePath());
       final PlatformManager pm = factory.createPlatformManager();
       final CountDownLatch latch = new CountDownLatch(1);


### PR DESCRIPTION
This patch adds a `systemPropertyVariables` configuration option, which allows you to define system properties to be set when running a module.

This is particularly useful for setting the `org.vertx.logger-delegate-factory-class-name` property (my use case).

The option name and concept comes from the Apache Maven Surefire plugin (https://maven.apache.org/surefire/maven-surefire-plugin/examples/system-properties.html).
