### PR TITLE
Use assembly to generate exploded module structure

### DIFF
--- a/archetype/src/main/resources/archetype-resources/pom.xml
+++ b/archetype/src/main/resources/archetype-resources/pom.xml
@@ -139,46 +139,6 @@
         </configuration>
       </plugin>
       <plugin>
-        <artifactId>maven-resources-plugin</artifactId>
-        <version>${maven.resources.plugin.version}</version>
-        <executions>
-          <execution>
-            <id>copy-mod-to-target</id>
-            <phase>process-classes</phase>
-            <goals>
-              <goal>copy-resources</goal>
-            </goals>
-            <configuration>
-              <overwrite>true</overwrite>
-              <outputDirectory>target/mods/${module.name}</outputDirectory>
-              <resources>
-                <resource>
-                  <directory>target/classes</directory>
-                </resource>
-              </resources>
-            </configuration>
-          </execution>
-        </executions>
-      </plugin>
-      <plugin>
-        <groupId>org.apache.maven.plugins</groupId>
-        <artifactId>maven-dependency-plugin</artifactId>
-        <version>${maven.dependency.plugin.version}</version>
-        <executions>
-          <execution>
-            <id>copy-mod-dependencies-to-target</id>
-            <phase>process-classes</phase>
-            <goals>
-              <goal>copy-dependencies</goal>
-            </goals>
-            <configuration>
-              <outputDirectory>target/mods/${module.name}/lib</outputDirectory>
-              <includeScope>runtime</includeScope>
-            </configuration>
-          </execution>
-        </executions>
-      </plugin>
-      <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-surefire-plugin</artifactId>
         <version>${maven.surefire.plugin.version}</version>
@@ -236,6 +196,9 @@
       <plugin>
         <artifactId>maven-assembly-plugin</artifactId>
         <configuration>
+          <outputDirectory>${project.build.directory}/mods</outputDirectory>
+          <finalName>${module.name}</finalName>
+          <appendAssemblyId>false</appendAssemblyId>
           <descriptors>
             <descriptor>src/main/assembly/mod.xml</descriptor>
           </descriptors>

--- a/archetype/src/main/resources/archetype-resources/src/main/assembly/mod.xml
+++ b/archetype/src/main/resources/archetype-resources/src/main/assembly/mod.xml
@@ -6,14 +6,23 @@
     <id>mod</id>
     <formats>
         <format>zip</format>
+        <format>dir</format>
     </formats>
 
     <includeBaseDirectory>false</includeBaseDirectory>
 
+    <dependencySets>
+        <dependencySet>
+            <useProjectArtifact>false</useProjectArtifact>
+            <outputDirectory>lib/</outputDirectory>
+            <scope>runtime</scope>
+            <fileMode>664</fileMode>
+        </dependencySet>
+    </dependencySets>
     <fileSets>
         <fileSet>
-            <outputDirectory></outputDirectory>
-            <directory>target/mods/${module.name}</directory>
+            <outputDirectory>/</outputDirectory>
+            <directory>${project.build.outputDirectory}</directory>
             <includes>
                 <include>**</include>
             </includes>


### PR DESCRIPTION
With this changes you use the _assembly_ plugin for creating the whole module structure. The main benefit of this is to remove a lot of plugin configurations from the project pom.xml. Also, as a side effect, you cannot be in the situation of having your module running differently from a custom assembly (with vertx runzip) and from the vert.x plugin.
