### PR TITLE
Updated to work with Vert.x 2.1M2

### DIFF
--- a/archetype/pom.xml
+++ b/archetype/pom.xml
@@ -10,7 +10,7 @@
 
   <groupId>io.vertx</groupId>
   <artifactId>vertx-maven-archetype</artifactId>
-  <version>2.0.1-final</version>
+  <version>2.0.1.1-final</version>
   <packaging>maven-archetype</packaging>
 
   <name>vertx-maven-archetype</name>

--- a/archetype/src/main/resources/archetype-resources/pom.xml
+++ b/archetype/src/main/resources/archetype-resources/pom.xml
@@ -36,7 +36,7 @@
     <mods.directory>target/mods</mods.directory>
 
     <!--Dependency versions-->
-    <vertx.version>2.1M1</vertx.version>
+    <vertx.version>2.1M2</vertx.version>
     <vertx.testtools.version>2.0.2-final</vertx.testtools.version>
     <junit.version>4.11</junit.version>
 

--- a/plugin/pom.xml
+++ b/plugin/pom.xml
@@ -10,7 +10,7 @@
 
   <groupId>io.vertx</groupId>
   <artifactId>vertx-maven-plugin</artifactId>
-  <version>2.0.2-SNAPSHOT</version>
+  <version>2.0.1.1</version>
   <packaging>maven-plugin</packaging>
 
   <name>vertx-maven-plugin</name>
@@ -36,7 +36,7 @@
 
   <properties>
     <maven.version>2.2.1</maven.version>
-    <vertx.version>2.1M1</vertx.version>
+    <vertx.version>2.1M2</vertx.version>
   </properties>
 
   <build>


### PR DESCRIPTION
Forked from 2.0.1-final (not including latests changes for Vert.x 2.1M3). 
This changes allows to use the Maven plugin with Vert.x 2.1M2. 
Current plugin version (2.0.1-final) uses 2.1M1 and if the project uses 2.1M2 it throws errors on execution (classes not found: CaseInsensitiveMultiMap for example)
