### PR TITLE
Supporting clustering and ha config for vertx:runMod 

### DIFF
--- a/plugin/src/main/java/org/vertx/maven/plugin/mojo/BaseVertxMojo.java
+++ b/plugin/src/main/java/org/vertx/maven/plugin/mojo/BaseVertxMojo.java
@@ -21,16 +21,23 @@ import org.apache.maven.plugins.annotations.Component;
 import org.apache.maven.plugins.annotations.Parameter;
 import org.apache.maven.project.MavenProject;
 import org.vertx.java.core.json.JsonObject;
+import org.vertx.java.platform.PlatformManager;
 
 import java.io.File;
 import java.io.IOException;
+import java.net.Inet6Address;
+import java.net.InetAddress;
+import java.net.NetworkInterface;
+import java.net.SocketException;
 import java.net.URI;
 import java.net.URL;
 import java.net.URLClassLoader;
 import java.util.ArrayList;
+import java.util.Enumeration;
 import java.util.List;
 
 import static java.nio.file.Files.readAllBytes;
+import static org.vertx.java.platform.PlatformLocator.factory;
 
 public abstract class BaseVertxMojo extends AbstractMojo {
 
@@ -73,6 +80,57 @@ public abstract class BaseVertxMojo extends AbstractMojo {
   @Parameter(defaultValue = "target/mods")
   protected File modsDir;
 
+  /**
+   * If specified then the vert.x instance will form a cluster with any other
+   * vert.x instances on the network. The default is false.
+   */
+  @Parameter(defaultValue = "false")
+  protected Boolean cluster;
+
+  /**
+   * Host to bind to for cluster communication. If this is not specified vert.x
+   * will attempt to choose one from the available interfaces.
+   */
+  @Parameter
+  protected String clusterHost;
+
+  /**
+   * The default is org.vertx.java.spi.cluster.impl.hazelcast.HazelcastClusterManagerFactory.
+   */
+  @Parameter(defaultValue = "org.vertx.java.spi.cluster.impl.hazelcast.HazelcastClusterManagerFactory")
+  protected String clusterManagerFactory;
+
+  /**
+   * Port to use for cluster communication. Default is 0 which means chose a
+   * spare random port.
+   */
+  @Parameter(defaultValue = "0")
+  protected Integer clusterPort;
+
+  /**
+   * If specified the module will be deployed as a high availability (HA)
+   * deployment. This means it can fail over to any other nodes in the cluster
+   * started with the same HA group.
+   */
+  @Parameter(defaultValue = "false")
+  protected Boolean ha;
+
+  /**
+   * Uused in conjunction with -ha this specifies the HA group this node will
+   * join. There can be multiple HA groups in a cluster. Nodes will only
+   * failover to other nodes in the same group. Defaults to __DEFAULT__
+   */
+  @Parameter(defaultValue = "__DEFAULT__")
+  protected String hagroup;
+
+  /**
+   * Used in conjunction with -ha this specifies the minimum number of nodes
+   * in the cluster for any HA deployments to be active. Defaults to 0.
+   */
+  @Parameter(defaultValue = "0")
+  protected Integer quorum;
+
+
   protected JsonObject getConf() {
     JsonObject config = null;
     final String confContent = readConfigFile(configFile);
@@ -93,6 +151,62 @@ public abstract class BaseVertxMojo extends AbstractMojo {
     } catch (final IOException e) {
       e.printStackTrace();
       // just returns an empty string. Nothing to be thrown
+    }
+
+    return null;
+  }
+
+  protected PlatformManager createPlatformManager() {
+    PlatformManager mgr;
+
+    if (cluster || ha) {
+      getLog().info("Starting clustering...");
+
+      if (System.getProperty("vertx.clusterManagerFactory", null) == null) {
+          getLog().debug("clusterManagerFactory: " + clusterManagerFactory);
+          System.setProperty("vertx.clusterManagerFactory", clusterManagerFactory);
+      }
+
+      if (clusterHost == null) {
+        clusterHost = getDefaultAddress();
+        if (clusterHost == null) {
+          getLog().error("Unable to find a default network interface for clustering. Please specify one using cluster-host configuration parameter");
+          return null;
+        } else {
+          getLog().info("No cluster-host specified so using address " + clusterHost);
+        }
+      }
+
+      if (ha) {
+        int quorumSize = quorum == null ? 0 : Integer.valueOf(quorum);
+        mgr = factory.createPlatformManager(clusterPort, clusterHost, quorumSize, hagroup);
+      } else {
+        mgr = factory.createPlatformManager(clusterPort, clusterHost);
+      }
+    } else {
+      mgr = factory.createPlatformManager();
+    }
+    return mgr;
+  }
+
+  private String getDefaultAddress() {
+    Enumeration<NetworkInterface> nets;
+    try {
+      nets = NetworkInterface.getNetworkInterfaces();
+    } catch (SocketException e) {
+      return null;
+    }
+
+    NetworkInterface netinf;
+    while (nets.hasMoreElements()) {
+      netinf = nets.nextElement();
+      Enumeration<InetAddress> addresses = netinf.getInetAddresses();
+      while (addresses.hasMoreElements()) {
+        InetAddress address = addresses.nextElement();
+        if (!address.isAnyLocalAddress() && !address.isMulticastAddress() && !(address instanceof Inet6Address)) {
+          return address.getHostAddress();
+        }
+      }
     }
 
     return null;

--- a/plugin/src/main/java/org/vertx/maven/plugin/mojo/VertxRunModMojo.java
+++ b/plugin/src/main/java/org/vertx/maven/plugin/mojo/VertxRunModMojo.java
@@ -47,7 +47,7 @@ public class VertxRunModMojo extends BaseVertxMojo {
 
       final CountDownLatch latch = new CountDownLatch(1);
 
-      final PlatformManager pm = factory.createPlatformManager();
+      final PlatformManager pm = createPlatformManager();
 
       pm.createModuleLink(moduleName, new Handler<AsyncResult<Void>>() {
         @Override


### PR DESCRIPTION
Additional configuration options:

<ul>
<li>cluster (default: false)</li>
<li>clusterHost</li>
<li>clusterPort (default 0)</li>
<li>clusterManagerFactory (default org.vertx.java.spi.cluster.impl.hazelcast.HazelcastClusterManagerFactory)</li>
<li>ha (default false)</li>
<li>hagroup (default __ DEFAULT __)</li>
<li>quorum (default 0)</li>
</ul>


Example that enables clustering with minimal config:

<pre>
&lt;configuration&gt;
    ...
    &lt;cluster&gt;true&lt;/cluster&gt;
&lt;/configuration&gt;
</pre>
