### PR TITLE
when a verticle is part of maven sub-module, the build target is being r...

### DIFF
--- a/plugin/src/main/java/org/vertx/maven/plugin/mojo/VertxFatJarMojo.java
+++ b/plugin/src/main/java/org/vertx/maven/plugin/mojo/VertxFatJarMojo.java
@@ -44,9 +44,8 @@ public class VertxFatJarMojo extends BaseVertxMojo {
       if (createFatJar) {
         System.setProperty("vertx.mods", modsDir.getAbsolutePath());
         final PlatformManager pm = factory.createPlatformManager();
-
         final CountDownLatch latch = new CountDownLatch(1);
-        pm.makeFatJar(moduleName, "target",
+        pm.makeFatJar(moduleName, project.getBuild().getDirectory(),
             new Handler<AsyncResult<Void>>() {
               @Override
               public void handle(final AsyncResult<Void> event) {


### PR DESCRIPTION
...eferred to parent module target folder. The fix is to refer to target of current reactor module.
