### PR TITLE
Maven should always output cluster factory

### DIFF
--- a/plugin/src/main/java/org/vertx/maven/plugin/mojo/BaseVertxMojo.java
+++ b/plugin/src/main/java/org/vertx/maven/plugin/mojo/BaseVertxMojo.java
@@ -163,9 +163,9 @@ public abstract class BaseVertxMojo extends AbstractMojo {
       getLog().info("Starting clustering...");
 
       if (System.getProperty("vertx.clusterManagerFactory", null) == null) {
-          getLog().debug("clusterManagerFactory: " + clusterManagerFactory);
           System.setProperty("vertx.clusterManagerFactory", clusterManagerFactory);
       }
+      getLog().debug("clusterManagerFactory: " + System.getProperty("vertx.clusterManagerFactory"));
 
       if (clusterHost == null) {
         clusterHost = getDefaultAddress();


### PR DESCRIPTION
Always ensure that debug level output displays the cluster factory
Closes #32

Note that we always retrieve the system property since that is the ultimate arbiter of which factory is used
